### PR TITLE
Update i18n?

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   i18n: {
-    locales: ["en"],
-    defaultLocale: "en"
+    locales: ["en-US"],
+    defaultLocale: "en-US"
   },
   images: {
     remotePatterns: [


### PR DESCRIPTION
NextJS 13 did some change to i18n: https://beta.nextjs.org/docs/guides/internationalization https://github.com/vercel/next.js/issues/41980